### PR TITLE
Update and rename [αVOID] to [OPTIMUMα]

### DIFF
--- a/Main/[OPTIMUMα]
+++ b/Main/[OPTIMUMα]
@@ -1,4 +1,4 @@
-# [αVOID]
+# [OPTIMUMα] :: AdGuard's Simplified Domains optimized for use with AdGuard Pro's DNS filitering. Notice: See original @ https://github.com/AdguardTeam/AdguardFilters/ for original & relevant licenses.
 ||007-gateway.com^
 ||04dn8g4f.space^
 ||0emn.com^


### PR DESCRIPTION
[OPTIMUMα] :: AdGuard's Simplified Domains optimized for use with AdGuard Pro’s DNS filtering.